### PR TITLE
Erc20 storage helpers

### DIFF
--- a/erc20/Cargo.lock
+++ b/erc20/Cargo.lock
@@ -5,7 +5,7 @@ name = "ahash"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "const-random 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "const-random 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -32,7 +32,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -42,13 +42,18 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "backtrace"
-version = "0.3.40"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -57,17 +62,16 @@ name = "backtrace-sys"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bincode"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -78,12 +82,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -93,7 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -117,20 +121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.3.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "c2-chacha"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "cc"
-version = "1.0.47"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -165,30 +161,30 @@ name = "cmake"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "const-random"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "const-random-macro 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "const-random-macro 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "const-random-macro"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -204,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cosmwasm 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -214,66 +210,66 @@ dependencies = [
  "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-nm 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-clif-backend 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-middleware-common 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-singlepass-backend 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-clif-backend 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-middleware-common 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime-core 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-singlepass-backend 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.44.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cranelift-entity 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-entity 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.44.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cranelift-bforest 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-codegen-meta 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-codegen-shared 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-entity 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-bforest 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen-meta 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen-shared 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-entity 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.44.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cranelift-codegen-shared 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-entity 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen-shared 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-entity 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.44.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.44.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cranelift-native"
-version = "0.44.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cranelift-codegen 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raw-cpuid 7.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -300,9 +296,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -321,14 +318,14 @@ name = "cw-erc20"
 version = "0.1.0"
 dependencies = [
  "cosmwasm 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cosmwasm-vm 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-vm 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage 0.1.1 (git+https://github.com/confio/cw-storage.git?branch=may_update)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "named_type 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "named_type_derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -336,7 +333,7 @@ dependencies = [
 [[package]]
 name = "cw-storage"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/confio/cw-storage.git?branch=may_update#4b5860f726c9f30d738358207eb0b2992e16913b"
 dependencies = [
  "cosmwasm 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "named_type 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -365,12 +362,12 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -378,7 +375,7 @@ name = "dynasmrt"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -393,7 +390,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -403,7 +400,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -411,7 +408,7 @@ name = "failure"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -420,9 +417,9 @@ name = "failure_derive"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -451,12 +448,12 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -473,7 +470,7 @@ name = "hermit-abi"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -488,26 +485,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "indexmap"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "lazy_static"
@@ -516,12 +504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.65"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lock_api"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -561,7 +549,7 @@ name = "memmap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -599,19 +587,19 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -637,12 +625,11 @@ dependencies = [
 
 [[package]]
 name = "page_size"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -650,7 +637,7 @@ name = "parity-wasm"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -669,7 +656,7 @@ name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -679,7 +666,7 @@ name = "parking_lot_core"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -692,7 +679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -700,18 +687,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "proc-macro-hack"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -724,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -748,7 +730,7 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -757,31 +739,10 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -798,51 +759,35 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "raw-cpuid"
-version = "6.1.0"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -883,7 +828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "schemars_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -891,10 +836,10 @@ name = "schemars_derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive_internals 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -928,7 +873,7 @@ name = "serde-bench"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -942,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -953,9 +898,9 @@ name = "serde_derive"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -963,24 +908,24 @@ name = "serde_derive_internals"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.41"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -998,11 +943,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "snafu"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1049,10 +999,10 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.8"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1070,21 +1020,16 @@ name = "synstructure"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "textwrap"
@@ -1092,6 +1037,24 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1131,7 +1094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasi"
-version = "0.7.0"
+version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1151,9 +1114,9 @@ dependencies = [
  "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1171,9 +1134,9 @@ name = "wasm-bindgen-macro-support"
 version = "0.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1195,126 +1158,120 @@ dependencies = [
 
 [[package]]
 name = "wasmer-clif-backend"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-codegen 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-entity 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-native 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-entity 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-native 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-bench 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-clif-fork-frontend 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-clif-fork-wasm 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-win-exception-handler 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.39.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-clif-fork-frontend 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-clif-fork-wasm 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime-core 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-win-exception-handler 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.45.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-clif-fork-frontend"
-version = "0.44.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cranelift-codegen 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-clif-fork-wasm"
-version = "0.44.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cranelift-codegen 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-entity 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-entity 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-clif-fork-frontend 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.39.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-clif-fork-frontend 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.45.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-middleware-common"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasmer-runtime-core 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime-core 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-runtime-core"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "page_size 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "page_size 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-bench 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.39.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.45.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-singlepass-backend"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dynasm 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dynasmrt 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime-core 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-win-exception-handler"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime-core 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.39.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
+version = "0.45.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1325,11 +1282,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1344,42 +1296,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6f33b5018f120946c1dcf279194f238a9f146725593ead1c08fa47ff22b0b5d3"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+"checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-"checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+"checksum backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e4036b9bf40f3cf16aba72a3d65e8a520fc4bafcdc7079aea8f848c58c5b5536"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
-"checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
+"checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0"
+"checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-"checksum cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
+"checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+"checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
-"checksum const-random 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7b641a8c9867e341f3295564203b1c250eb8ce6cb6126e007941f78c4d2ed7fe"
-"checksum const-random-macro 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c750ec12b83377637110d5a57f5ae08e895b06c4b16e2bdbf1a94ef717428c59"
-"checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
+"checksum const-random 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
+"checksum const-random-macro 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
+"checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum cosmwasm 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b211918dc76c1ef73f50a6e5f099a7676399b6d4211070701e1de3c143692d88"
-"checksum cosmwasm-vm 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ed366d35b38f8dd1530fdb5d28ab834a5d04c1de2fcd1c60beba6132acd78c78"
-"checksum cranelift-bforest 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fff04f4ad82c9704a22e753c6268cc6a89add76f094b837cefbba1c665411451"
-"checksum cranelift-codegen 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ff4a221ec1b95df4b1d20a99fec4fe92a28bebf3a815f2eca72b26f9a627485"
-"checksum cranelift-codegen-meta 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd47f665e2ee8f177b97d1f5ce2bd70f54d3b793abb26d92942bfaa4a381fe9f"
-"checksum cranelift-codegen-shared 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05bb95945fd940bd5fc2616b063ce69e55de3d9449a32fa40f6bb99a927085bf"
-"checksum cranelift-entity 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e8753f15d9bde04988834705d437b6f6e4b4da0527968b8d40d7342262d43052"
-"checksum cranelift-native 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd16b58e95af9ee837218cf41e70306becc1fc7d7dada55dac42df5130a4a4ba"
+"checksum cosmwasm-vm 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72e29718243ff2469f35eca502a5e69332c3615b9cbc0db7d97b3af85d7df5db"
+"checksum cranelift-bforest 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "56aa72ef104c5d634f2f9e84ef2c47e116c1d185fae13f196b97ca84b0a514f1"
+"checksum cranelift-codegen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "460b9d20793543599308d22f5a1172c196e63a780c4e9aacb0b3f4f63d63ffe1"
+"checksum cranelift-codegen-meta 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc70e4e8ccebd53a4f925147def857c9e9f7fe0fdbef4bb645a420473e012f50"
+"checksum cranelift-codegen-shared 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3992000be4d18df0fe332b7c42c120de896e8ec54cd7b6cfa050910a8c9f6e2f"
+"checksum cranelift-entity 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "722957e05064d97a3157bf0976deed0f3e8ee4f8a4ce167a7c724ca63a4e8bd9"
+"checksum cranelift-native 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "21398a0bc6ba389ea86964ac4a495426dd61080f2ddd306184777a8560fe9976"
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 "checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
-"checksum crossbeam-queue 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700"
+"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
-"checksum cw-storage 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31e777074eb3fff69ac20cbce138d48530674d73e385ae32a2ad7bfd229d1e05"
+"checksum cw-storage 0.1.1 (git+https://github.com/confio/cw-storage.git?branch=may_update)" = "<none>"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 "checksum dynasm 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "42a814e1edeb85dd2a3c6fc0d6bf76d02ca5695d438c70ecee3d90774f3259c5"
@@ -1393,17 +1345,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
+"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 "checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
-"checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
-"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
-"checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
+"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+"checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e542a8a0a1309ceed0614dbb910658c118f4ff40b0ed31a1bf77a869a5a1853"
@@ -1414,33 +1365,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum named_type 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a9b45469f7e8314cd4a0791e914c5b65c02ba6451c0662eeb29ccc1714013d7"
 "checksum named_type_derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c13c91ae49fb502a04f2e993e63e06a28fc5a1ecff01eaa09448735c7ad1243b"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
-"checksum num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72"
+"checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum page_size 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f89ef58b3d32420dbd1a43d2f38ae92f6239ef12bb556ab09ca55445f5a67242"
+"checksum page_size 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 "checksum parity-wasm 0.19.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d50271cd6cdd7643b5e601aaf9e65285bcfe740f849125e4986263160519fe9"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+"checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-"checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
-"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-"checksum raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "30a9d219c32c9132f7be513c18be77c9881c7107d2ab5569d205a6a0f0e6dc7d"
-"checksum rayon 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43739f8831493b276363637423d3622d4bd6394ab6f0a9c4a552e208aeb7fddd"
-"checksum rayon-core 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8bf17de6f23b05473c437eb958b9c850bfc8af0961fe17b4cc92d5a627b4791"
+"checksum raw-cpuid 7.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
+"checksum rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+"checksum rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
@@ -1454,23 +1400,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
 "checksum serde-bench 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d733da87e79faaac25616e33d26299a41143fd4cd42746cbb0e91d8feea243fd"
 "checksum serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b135e77909913dd4120633eba0322937456ec78856d3b578e777d582d317deb5"
-"checksum serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "45af0182ff64abaeea290235eb67da3825a576c5d53e642c4d5b652e12e6effc"
+"checksum serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
 "checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
 "checksum serde_derive_internals 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
-"checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
-"checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
+"checksum serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "15913895b61e0be854afd32fd4163fcd2a3df34142cf2cb961b310ce694cbf90"
+"checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+"checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d0bf93d08d6a44363b47d737f1f5bebbf5e6a1eaaa3d4c128ceeaca6b718292"
 "checksum snafu-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "624e94bd38e471f67883b467711e7a7ad7dbe284f5fb7e661dc8a671fc5b26a0"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
+"checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-"checksum target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7975cb2c6f37d77b190bc5004a2bb015971464756fde9514651a525ada2a741a"
+"checksum target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4c118a7a38378f305a9e111fcb2f7f838c0be324bfb31a77ea04f7f6e684b4"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "205684fd018ca14432b12cce6ea3d46763311a571c3d294e71ba3f01adcf1aad"
+"checksum thiserror-impl 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "57e4d2e50ca050ed44fb58309bdce3efa79948f84f9993ad1978de5eebdce5a7"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
@@ -1478,23 +1427,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
+"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "29ae32af33bacd663a9a28241abecf01f2be64e6a185c6139b04f18b6385c5f2"
 "checksum wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "1845584bd3593442dc0de6e6d9f84454a59a057722f36f005e44665d6ab19d85"
 "checksum wasm-bindgen-macro 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "87fcc747e6b73c93d22c947a6334644d22cfec5abd8b66238484dc2b0aeb9fe4"
 "checksum wasm-bindgen-macro-support 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "3dc4b3f2c4078c8c4a5f363b92fcf62604c5913cbd16c6ff5aaf0f74ec03f570"
 "checksum wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "ca0b78d6d3be8589b95d1d49cdc0794728ca734adf36d7c9f07e6459508bb53d"
 "checksum wasm-nm 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8cf59724f173a3ec1f7f981ee8f54bd8902249bfaac691af61f0755105a062a"
-"checksum wasmer-clif-backend 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af5e6d28680bad6e00cb9e23067fcf34864b83073275350cfc702d61f0506006"
-"checksum wasmer-clif-fork-frontend 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0cf2f552a9c1fda0555087170424bd8fedc63a079a97bb5638a4ef9b0d9656aa"
-"checksum wasmer-clif-fork-wasm 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0073b512e1af5948d34be7944b74c747bbe735ccff2e2f28c26ed4c90725de8e"
-"checksum wasmer-middleware-common 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1e2a862973c65876c18ad1e4cdd2d3c768743732f186cea8a3d6d00a1c4a7ec7"
-"checksum wasmer-runtime-core 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb4f8813166af93c87abcbe51fd0aa11977747398a13e28d18b6126fcc1a158b"
-"checksum wasmer-singlepass-backend 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "59b4da3d70e00f598633e2779f4dd4d6ed41f9cadb235a273d05b1ccd69ee805"
-"checksum wasmer-win-exception-handler 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f34396da3d206384f19095e0954b846219bea0fb2dc42231d726d79682bfeda"
-"checksum wasmparser 0.39.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c702914acda5feeeffbc29e4d953e5b9ce79d8b98da4dbf18a77086e116c5470"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum wasmer-clif-backend 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c785ab26863bd64d2ce2956083c3db9a09d7d639b6205baee6e54f258f94e034"
+"checksum wasmer-clif-fork-frontend 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2e13201ef9ef527ad30a6bf1b08e3e024a40cf2731f393d80375dc88506207"
+"checksum wasmer-clif-fork-wasm 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8b09302cc4fdc4efc03823cb3e1880b0fde578ba43f27ddd212811cb28c1530"
+"checksum wasmer-middleware-common 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d8d3abfc32cc9556bee98e81b3aaa44a1b91c850795368528116f0d505c21b3"
+"checksum wasmer-runtime-core 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7b1131f1bb9a0610eeef2974275de019027fa8dcfac78a9976439ce5f4561ade"
+"checksum wasmer-singlepass-backend 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae95c8c55b15261a4e99cc8a2eaebf8e63051c4400b2c85209964dac9a811820"
+"checksum wasmer-win-exception-handler 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eac6af8ef69d582a851bb116be4faebc42d1f52ef00922e1688f3eff48d0d96b"
+"checksum wasmparser 0.45.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8b4eab1d9971d0803729cba3617b56eb04fcb4bd25361cb63880ed41a42f20d5"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/erc20/Cargo.toml
+++ b/erc20/Cargo.toml
@@ -31,7 +31,8 @@ singlepass = [ "cosmwasm-vm/default-singlepass"]
 
 [dependencies]
 cosmwasm = { version = "0.6.4" }
-cw-storage = "0.1.1"
+#cw-storage = "0.1.1"
+cw-storage = { git = "https://github.com/confio/cw-storage.git", branch = "may_update" }
 schemars = "=0.5"
 named_type = "=0.2.1"
 named_type_derive = "=0.2.1"

--- a/erc20/examples/schema.rs
+++ b/erc20/examples/schema.rs
@@ -4,9 +4,8 @@ use std::path::PathBuf;
 
 use schemars::{schema::RootSchema, schema_for};
 
-use cw_erc20::contract::{
-    AllowanceResponse, BalanceResponse, Constants, HandleMsg, InitMsg, QueryMsg,
-};
+use cw_erc20::msg::{AllowanceResponse, BalanceResponse, HandleMsg, InitMsg, QueryMsg};
+use cw_erc20::state::Constants;
 
 fn main() {
     let mut pwd = current_dir().unwrap();

--- a/erc20/schema/allowance_response.json
+++ b/erc20/schema/allowance_response.json
@@ -7,6 +7,11 @@
   ],
   "properties": {
     "allowance": {
+      "$ref": "#/definitions/Amount"
+    }
+  },
+  "definitions": {
+    "Amount": {
       "type": "string"
     }
   }

--- a/erc20/schema/balance_response.json
+++ b/erc20/schema/balance_response.json
@@ -7,6 +7,11 @@
   ],
   "properties": {
     "balance": {
+      "$ref": "#/definitions/Amount"
+    }
+  },
+  "definitions": {
+    "Amount": {
       "type": "string"
     }
   }

--- a/erc20/schema/handle_msg.json
+++ b/erc20/schema/handle_msg.json
@@ -16,7 +16,7 @@
           ],
           "properties": {
             "amount": {
-              "type": "string"
+              "$ref": "#/definitions/Amount"
             },
             "spender": {
               "$ref": "#/definitions/HumanAddr"
@@ -39,7 +39,7 @@
           ],
           "properties": {
             "amount": {
-              "type": "string"
+              "$ref": "#/definitions/Amount"
             },
             "recipient": {
               "$ref": "#/definitions/HumanAddr"
@@ -63,7 +63,7 @@
           ],
           "properties": {
             "amount": {
-              "type": "string"
+              "$ref": "#/definitions/Amount"
             },
             "owner": {
               "$ref": "#/definitions/HumanAddr"
@@ -77,6 +77,9 @@
     }
   ],
   "definitions": {
+    "Amount": {
+      "type": "string"
+    },
     "HumanAddr": {
       "type": "string"
     }

--- a/erc20/schema/init_msg.json
+++ b/erc20/schema/init_msg.json
@@ -28,6 +28,9 @@
     }
   },
   "definitions": {
+    "Amount": {
+      "type": "string"
+    },
     "HumanAddr": {
       "type": "string"
     },
@@ -42,7 +45,7 @@
           "$ref": "#/definitions/HumanAddr"
         },
         "amount": {
-          "type": "string"
+          "$ref": "#/definitions/Amount"
         }
       }
     }

--- a/erc20/src/contract.rs
+++ b/erc20/src/contract.rs
@@ -135,8 +135,11 @@ fn perform_transfer<T: Storage>(
     to: &CanonicalAddr,
     amount: &Amount,
 ) -> Result<()> {
-    balances(store).update(from.as_bytes(), &|current: Amount| current.subtract(amount))?;
-    balances(store).update(to.as_bytes(), &|current: Amount| current.add(amount))?;
+    balances(store).update(from.as_bytes(), &|current| current.subtract(amount))?;
+    balances(store).may_update(to.as_bytes(), &|current| {
+        let updated = current.unwrap_or_default().add(amount)?;
+        Ok(Some(updated))
+    })?;
     Ok(())
 }
 

--- a/erc20/src/contract.rs
+++ b/erc20/src/contract.rs
@@ -1,13 +1,12 @@
-use std::convert::TryInto;
-
-use cosmwasm::errors::{contract_err, dyn_contract_err, Result};
-use cosmwasm::traits::{Api, Extern, ReadonlyStorage, Storage};
+use cosmwasm::errors::{contract_err, Result};
+use cosmwasm::traits::{Api, Extern, Storage};
 use cosmwasm::types::{CanonicalAddr, HumanAddr, Params, Response};
-use cw_storage::{serialize, PrefixedStorage, ReadonlyPrefixedStorage};
+use cw_storage::serialize;
 
 use crate::msg::{AllowanceResponse, BalanceResponse, HandleMsg, InitMsg, QueryMsg};
 use crate::state::{
-    constants, total_supply, Amount, Constants, PREFIX_ALLOWANCES, PREFIX_BALANCES,
+    allowances, allowances_read, balances, balances_read, constants, total_supply, Amount,
+    Constants,
 };
 
 pub fn init<S: Storage, A: Api>(
@@ -18,11 +17,11 @@ pub fn init<S: Storage, A: Api>(
     let mut total: u128 = 0;
     {
         // Initial balances
-        let mut balances_store = PrefixedStorage::new(PREFIX_BALANCES, &mut deps.storage);
+        let mut balances_store = balances(&mut deps.storage);
         for row in msg.initial_balances {
             let raw_address = deps.api.canonical_address(&row.address)?;
             let amount_raw = row.amount.parse()?;
-            balances_store.set(raw_address.as_bytes(), &amount_raw.to_be_bytes());
+            balances_store.save(raw_address.as_bytes(), &row.amount)?;
             total += amount_raw;
         }
     }
@@ -69,20 +68,18 @@ pub fn query<S: Storage, A: Api>(deps: &Extern<S, A>, msg: QueryMsg) -> Result<V
     match msg {
         QueryMsg::Balance { address } => {
             let address_key = deps.api.canonical_address(&address)?;
-            let balance = read_balance(&deps.storage, &address_key)?;
-            let out = serialize(&BalanceResponse {
-                balance: Amount::from(balance),
-            })?;
-            Ok(out)
+            let balance = balances_read(&deps.storage)
+                .may_load(address_key.as_bytes())?
+                .unwrap_or_default();
+            serialize(&BalanceResponse { balance })
         }
         QueryMsg::Allowance { owner, spender } => {
             let owner_key = deps.api.canonical_address(&owner)?;
             let spender_key = deps.api.canonical_address(&spender)?;
-            let allowance = read_allowance(&deps.storage, &owner_key, &spender_key)?;
-            let out = serialize(&AllowanceResponse {
-                allowance: Amount::from(allowance),
-            })?;
-            Ok(out)
+            let allowance = allowances_read(&deps.storage, &owner_key)
+                .may_load(spender_key.as_bytes())?
+                .unwrap_or_default();
+            serialize(&AllowanceResponse { allowance })
         }
     }
 }
@@ -95,21 +92,15 @@ fn try_transfer<S: Storage, A: Api>(
 ) -> Result<Response> {
     let sender_address_raw = &params.message.signer;
     let recipient_address_raw = deps.api.canonical_address(recipient)?;
-    let amount_raw = amount.parse()?;
+    amount.validate()?;
 
     perform_transfer(
         &mut deps.storage,
         &sender_address_raw,
         &recipient_address_raw,
-        amount_raw,
+        amount,
     )?;
-
-    let res = Response {
-        messages: vec![],
-        log: Some("transfer successful".to_string()),
-        data: None,
-    };
-    Ok(res)
+    Ok(response_with_log("transfer successful"))
 }
 
 fn try_transfer_from<S: Storage, A: Api>(
@@ -119,38 +110,22 @@ fn try_transfer_from<S: Storage, A: Api>(
     recipient: &HumanAddr,
     amount: &Amount,
 ) -> Result<Response> {
-    let spender_address_raw = &params.message.signer;
+    let spender_address_raw = params.message.signer.as_bytes();
     let owner_address_raw = deps.api.canonical_address(owner)?;
     let recipient_address_raw = deps.api.canonical_address(recipient)?;
-    let amount_raw = amount.parse()?;
 
-    let mut allowance = read_allowance(&deps.storage, &owner_address_raw, &spender_address_raw)?;
-    if allowance < amount_raw {
-        return dyn_contract_err(format!(
-            "Insufficient allowance: allowance={}, required={}",
-            allowance, amount_raw
-        ));
-    }
-    allowance -= amount_raw;
-    write_allowance(
-        &mut deps.storage,
-        &owner_address_raw,
-        &spender_address_raw,
-        allowance,
-    );
+    allowances(&mut deps.storage, &owner_address_raw)
+        .update(spender_address_raw, &|current: Amount| {
+            current.subtract(amount)
+        })?;
+
     perform_transfer(
         &mut deps.storage,
         &owner_address_raw,
         &recipient_address_raw,
-        amount_raw,
+        amount,
     )?;
-
-    let res = Response {
-        messages: vec![],
-        log: Some("transfer from successful".to_string()),
-        data: None,
-    };
-    Ok(res)
+    Ok(response_with_log("transfer from successful"))
 }
 
 fn try_approve<S: Storage, A: Api>(
@@ -161,88 +136,29 @@ fn try_approve<S: Storage, A: Api>(
 ) -> Result<Response> {
     let owner_address_raw = &params.message.signer;
     let spender_address_raw = deps.api.canonical_address(spender)?;
-    let amount_raw = amount.parse()?;
-    write_allowance(
-        &mut deps.storage,
-        &owner_address_raw,
-        &spender_address_raw,
-        amount_raw,
-    );
-    let res = Response {
-        messages: vec![],
-        log: Some("approve successful".to_string()),
-        data: None,
-    };
-    Ok(res)
+    amount.validate()?;
+    allowances(&mut deps.storage, &owner_address_raw)
+        .save(spender_address_raw.as_bytes(), amount)?;
+    Ok(response_with_log("approve successful"))
 }
 
 fn perform_transfer<T: Storage>(
     store: &mut T,
     from: &CanonicalAddr,
     to: &CanonicalAddr,
-    amount: u128,
+    amount: &Amount,
 ) -> Result<()> {
-    let mut balances_store = PrefixedStorage::new(PREFIX_BALANCES, store);
-
-    let mut from_balance = read_u128(&balances_store, from.as_bytes())?;
-    if from_balance < amount {
-        return dyn_contract_err(format!(
-            "Insufficient funds: balance={}, required={}",
-            from_balance, amount
-        ));
-    }
-    from_balance -= amount;
-    balances_store.set(from.as_bytes(), &from_balance.to_be_bytes());
-
-    let mut to_balance = read_u128(&balances_store, to.as_bytes())?;
-    to_balance += amount;
-    balances_store.set(to.as_bytes(), &to_balance.to_be_bytes());
-
+    balances(store).update(from.as_bytes(), &|current: Amount| current.subtract(amount))?;
+    balances(store).update(to.as_bytes(), &|current: Amount| current.add(amount))?;
     Ok(())
 }
 
-// Converts 16 bytes value into u128
-// Errors if data found that is not 16 bytes
-pub fn bytes_to_u128(data: &[u8]) -> Result<u128> {
-    match data[0..16].try_into() {
-        Ok(bytes) => Ok(u128::from_be_bytes(bytes)),
-        Err(_) => contract_err("Corrupted data found. 16 byte expected."),
+fn response_with_log(msg: &str) -> Response {
+    Response {
+        messages: vec![],
+        log: Some(msg.to_string()),
+        data: None,
     }
-}
-
-// Reads 16 byte storage value into u128
-// Returns zero if key does not exist. Errors if data found that is not 16 bytes
-pub fn read_u128<S: ReadonlyStorage>(store: &S, key: &[u8]) -> Result<u128> {
-    return match store.get(key) {
-        Some(data) => bytes_to_u128(&data),
-        None => Ok(0u128),
-    };
-}
-
-fn read_balance<S: Storage>(store: &S, owner: &CanonicalAddr) -> Result<u128> {
-    let balance_store = ReadonlyPrefixedStorage::new(PREFIX_BALANCES, store);
-    return read_u128(&balance_store, owner.as_bytes());
-}
-
-fn read_allowance<S: Storage>(
-    store: &S,
-    owner: &CanonicalAddr,
-    spender: &CanonicalAddr,
-) -> Result<u128> {
-    let allowances_store = ReadonlyPrefixedStorage::new(PREFIX_ALLOWANCES, store);
-    let owner_store = ReadonlyPrefixedStorage::new(owner.as_bytes(), &allowances_store);
-    return read_u128(&owner_store, spender.as_bytes());
-}
-
-fn write_allowance<S: Storage>(
-    store: &mut S,
-    owner: &CanonicalAddr,
-    spender: &CanonicalAddr,
-    amount: u128,
-) -> () {
-    let mut allowances_store = PrefixedStorage::new(PREFIX_ALLOWANCES, store);
-    let mut owner_store = PrefixedStorage::new(owner.as_bytes(), &mut allowances_store);
-    owner_store.set(spender.as_bytes(), &amount.to_be_bytes());
 }
 
 fn is_valid_name(name: &str) -> bool {

--- a/erc20/src/contract.rs
+++ b/erc20/src/contract.rs
@@ -1,7 +1,3 @@
-use named_type::NamedType;
-use named_type_derive::NamedType;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 
 use cosmwasm::errors::{contract_err, dyn_contract_err, Result};
@@ -9,73 +5,10 @@ use cosmwasm::traits::{Api, Extern, ReadonlyStorage, Storage};
 use cosmwasm::types::{CanonicalAddr, HumanAddr, Params, Response};
 use cw_storage::{serialize, PrefixedStorage, ReadonlyPrefixedStorage};
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
-pub struct InitialBalance {
-    pub address: HumanAddr,
-    pub amount: String,
-}
-
-#[derive(Serialize, Deserialize, JsonSchema)]
-pub struct InitMsg {
-    pub name: String,
-    pub symbol: String,
-    pub decimals: u8,
-    pub initial_balances: Vec<InitialBalance>,
-}
-
-#[derive(Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum HandleMsg {
-    Approve {
-        spender: HumanAddr,
-        amount: String,
-    },
-    Transfer {
-        recipient: HumanAddr,
-        amount: String,
-    },
-    TransferFrom {
-        owner: HumanAddr,
-        recipient: HumanAddr,
-        amount: String,
-    },
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum QueryMsg {
-    Balance {
-        address: HumanAddr,
-    },
-    Allowance {
-        owner: HumanAddr,
-        spender: HumanAddr,
-    },
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
-pub struct BalanceResponse {
-    pub balance: String,
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
-pub struct AllowanceResponse {
-    pub allowance: String,
-}
-
-#[derive(Serialize, Debug, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
-pub struct Constants {
-    pub name: String,
-    pub symbol: String,
-    pub decimals: u8,
-}
-
-pub const PREFIX_CONFIG: &[u8] = b"config";
-pub const PREFIX_BALANCES: &[u8] = b"balances";
-pub const PREFIX_ALLOWANCES: &[u8] = b"allowances";
-
-pub const KEY_CONSTANTS: &[u8] = b"constants";
-pub const KEY_TOTAL_SUPPLY: &[u8] = b"total_supply";
+use crate::msg::{AllowanceResponse, BalanceResponse, HandleMsg, InitMsg, QueryMsg};
+use crate::state::{
+    Constants, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES, PREFIX_CONFIG,
+};
 
 pub fn init<S: Storage, A: Api>(
     deps: &mut Extern<S, A>,

--- a/erc20/src/lib.rs
+++ b/erc20/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod contract;
+pub mod msg;
+pub mod state;
 
 #[cfg(test)]
 mod tests;

--- a/erc20/src/msg.rs
+++ b/erc20/src/msg.rs
@@ -1,0 +1,60 @@
+use named_type::NamedType;
+use named_type_derive::NamedType;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm::types::HumanAddr;
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
+pub struct InitialBalance {
+    pub address: HumanAddr,
+    pub amount: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct InitMsg {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    pub initial_balances: Vec<InitialBalance>,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum HandleMsg {
+    Approve {
+        spender: HumanAddr,
+        amount: String,
+    },
+    Transfer {
+        recipient: HumanAddr,
+        amount: String,
+    },
+    TransferFrom {
+        owner: HumanAddr,
+        recipient: HumanAddr,
+        amount: String,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum QueryMsg {
+    Balance {
+        address: HumanAddr,
+    },
+    Allowance {
+        owner: HumanAddr,
+        spender: HumanAddr,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
+pub struct BalanceResponse {
+    pub balance: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
+pub struct AllowanceResponse {
+    pub allowance: String,
+}

--- a/erc20/src/msg.rs
+++ b/erc20/src/msg.rs
@@ -5,10 +5,12 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm::types::HumanAddr;
 
+use crate::state::Amount;
+
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
 pub struct InitialBalance {
     pub address: HumanAddr,
-    pub amount: String,
+    pub amount: Amount,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]
@@ -24,16 +26,16 @@ pub struct InitMsg {
 pub enum HandleMsg {
     Approve {
         spender: HumanAddr,
-        amount: String,
+        amount: Amount,
     },
     Transfer {
         recipient: HumanAddr,
-        amount: String,
+        amount: Amount,
     },
     TransferFrom {
         owner: HumanAddr,
         recipient: HumanAddr,
-        amount: String,
+        amount: Amount,
     },
 }
 
@@ -51,10 +53,10 @@ pub enum QueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
 pub struct BalanceResponse {
-    pub balance: String,
+    pub balance: Amount,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
 pub struct AllowanceResponse {
-    pub allowance: String,
+    pub allowance: Amount,
 }

--- a/erc20/src/msg.rs
+++ b/erc20/src/msg.rs
@@ -3,6 +3,7 @@ use named_type_derive::NamedType;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use cosmwasm::errors::{contract_err, Result};
 use cosmwasm::types::HumanAddr;
 
 use crate::state::Amount;
@@ -13,12 +14,39 @@ pub struct InitialBalance {
     pub amount: Amount,
 }
 
+impl InitialBalance {
+    pub fn valid_amount(&self) -> Result<u128> {
+        // ideally we validate the human address as well
+        self.amount.parse()
+    }
+}
+
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct InitMsg {
     pub name: String,
     pub symbol: String,
     pub decimals: u8,
     pub initial_balances: Vec<InitialBalance>,
+}
+
+impl InitMsg {
+    // validate the message and return total amount
+    pub fn valid_total(&self) -> Result<u128> {
+        // Check name, symbol, decimals
+        if !is_valid_name(&self.name) {
+            return contract_err("Name is not in the expected format (3-30 UTF-8 bytes)");
+        }
+        if !is_valid_symbol(&self.symbol) {
+            return contract_err("Ticker symbol is not in expected format [A-Z]{3,6}");
+        }
+        if self.decimals > 18 {
+            return contract_err("Decimals must not exceed 18");
+        }
+        // make sure all balances are valid and get the total
+        self.initial_balances
+            .iter()
+            .fold(Ok(0u128), |acc, bal| Ok(acc? + bal.valid_amount()?))
+    }
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]
@@ -37,6 +65,16 @@ pub enum HandleMsg {
         recipient: HumanAddr,
         amount: Amount,
     },
+}
+
+impl HandleMsg {
+    pub fn validate(&self) -> Result<()> {
+        match self {
+            HandleMsg::Approve { amount, .. } => amount.validate(),
+            HandleMsg::Transfer { amount, .. } => amount.validate(),
+            HandleMsg::TransferFrom { amount, .. } => amount.validate(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -59,4 +97,27 @@ pub struct BalanceResponse {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
 pub struct AllowanceResponse {
     pub allowance: Amount,
+}
+
+fn is_valid_name(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    if bytes.len() < 3 || bytes.len() > 30 {
+        return false;
+    }
+    return true;
+}
+
+fn is_valid_symbol(symbol: &str) -> bool {
+    let bytes = symbol.as_bytes();
+    if bytes.len() < 3 || bytes.len() > 6 {
+        return false;
+    }
+
+    for byte in bytes.iter() {
+        if *byte < 65 || *byte > 90 {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/erc20/src/state.rs
+++ b/erc20/src/state.rs
@@ -1,0 +1,20 @@
+use named_type::NamedType;
+use named_type_derive::NamedType;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+//use cw_storage::{serialize, PrefixedStorage, ReadonlyPrefixedStorage};
+
+pub const PREFIX_CONFIG: &[u8] = b"config";
+pub const PREFIX_BALANCES: &[u8] = b"balances";
+pub const PREFIX_ALLOWANCES: &[u8] = b"allowances";
+
+pub const KEY_CONSTANTS: &[u8] = b"constants";
+pub const KEY_TOTAL_SUPPLY: &[u8] = b"total_supply";
+
+#[derive(Serialize, Debug, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
+pub struct Constants {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+}

--- a/erc20/src/state.rs
+++ b/erc20/src/state.rs
@@ -3,6 +3,7 @@ use named_type_derive::NamedType;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use cosmwasm::errors::{contract_err, Result};
 //use cw_storage::{serialize, PrefixedStorage, ReadonlyPrefixedStorage};
 
 pub const PREFIX_CONFIG: &[u8] = b"config";
@@ -17,4 +18,119 @@ pub struct Constants {
     pub name: String,
     pub symbol: String,
     pub decimals: u8,
+}
+
+#[derive(Serialize, Debug, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
+/// Source must be a decadic integer >= 0
+pub struct Amount(String);
+
+impl Amount {
+    pub fn parse(&self) -> Result<u128> {
+        match self.0.parse::<u128>() {
+            Ok(value) => Ok(value),
+            Err(_) => contract_err("Error while parsing string to u128"),
+        }
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        let _ = self.parse()?;
+        Ok(())
+    }
+}
+
+impl From<u128> for Amount {
+    fn from(val: u128) -> Self {
+        Amount(val.to_string())
+    }
+}
+
+impl From<&str> for Amount {
+    fn from(raw: &str) -> Self {
+        Amount(raw.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Amount;
+    use cosmwasm::errors::{Error, Result};
+
+    fn parse_u128(val: &str) -> Result<u128> {
+        Amount::from(val).parse()
+    }
+
+    #[test]
+    fn works_for_simple_inputs() {
+        assert_eq!(parse_u128("0").expect("could not be parsed"), 0);
+        assert_eq!(parse_u128("1").expect("could not be parsed"), 1);
+        assert_eq!(parse_u128("345").expect("could not be parsed"), 345);
+        assert_eq!(
+            parse_u128("340282366920938463463374607431768211455").expect("could not be parsed"),
+            340282366920938463463374607431768211455
+        );
+    }
+
+    #[test]
+    fn works_for_leading_zeros() {
+        assert_eq!(parse_u128("01").expect("could not be parsed"), 1);
+        assert_eq!(parse_u128("001").expect("could not be parsed"), 1);
+        assert_eq!(parse_u128("0001").expect("could not be parsed"), 1);
+    }
+
+    #[test]
+    fn errors_for_empty_input() {
+        match parse_u128("") {
+            Ok(_) => panic!("must not pass"),
+            Err(Error::ContractErr { msg, .. }) => {
+                assert_eq!(msg, "Error while parsing string to u128")
+            }
+            Err(e) => panic!("unexpected error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn errors_for_values_out_of_range() {
+        match parse_u128("-1") {
+            Ok(_) => panic!("must not pass"),
+            Err(Error::ContractErr { msg, .. }) => {
+                assert_eq!(msg, "Error while parsing string to u128")
+            }
+            Err(e) => panic!("unexpected error: {:?}", e),
+        }
+
+        match parse_u128("340282366920938463463374607431768211456") {
+            Ok(_) => panic!("must not pass"),
+            Err(Error::ContractErr { msg, .. }) => {
+                assert_eq!(msg, "Error while parsing string to u128")
+            }
+            Err(e) => panic!("unexpected error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn fails_for_non_decadic_strings() {
+        match parse_u128("0xAB") {
+            Ok(_) => panic!("must not pass"),
+            Err(Error::ContractErr { msg, .. }) => {
+                assert_eq!(msg, "Error while parsing string to u128")
+            }
+            Err(e) => panic!("unexpected error: {:?}", e),
+        }
+
+        match parse_u128("0xab") {
+            Ok(_) => panic!("must not pass"),
+            Err(Error::ContractErr { msg, .. }) => {
+                assert_eq!(msg, "Error while parsing string to u128")
+            }
+            Err(e) => panic!("unexpected error: {:?}", e),
+        }
+
+        match parse_u128("0b1100") {
+            Ok(_) => panic!("must not pass"),
+            Err(Error::ContractErr { msg, .. }) => {
+                assert_eq!(msg, "Error while parsing string to u128")
+            }
+            Err(e) => panic!("unexpected error: {:?}", e),
+        }
+    }
 }

--- a/erc20/src/state.rs
+++ b/erc20/src/state.rs
@@ -4,14 +4,14 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm::errors::{contract_err, Result};
-//use cw_storage::{serialize, PrefixedStorage, ReadonlyPrefixedStorage};
+use cosmwasm::traits::{ReadonlyStorage, Storage};
+use cw_storage::{singleton, singleton_read, ReadonlySingleton, Singleton};
 
-pub const PREFIX_CONFIG: &[u8] = b"config";
 pub const PREFIX_BALANCES: &[u8] = b"balances";
 pub const PREFIX_ALLOWANCES: &[u8] = b"allowances";
 
-pub const KEY_CONSTANTS: &[u8] = b"constants";
-pub const KEY_TOTAL_SUPPLY: &[u8] = b"total_supply";
+const KEY_CONSTANTS: &[u8] = b"constants";
+const KEY_TOTAL_SUPPLY: &[u8] = b"total_supply";
 
 #[derive(Serialize, Debug, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
 pub struct Constants {
@@ -48,6 +48,22 @@ impl From<&str> for Amount {
     fn from(raw: &str) -> Self {
         Amount(raw.to_string())
     }
+}
+
+pub fn constants<S: Storage>(storage: &mut S) -> Singleton<S, Constants> {
+    singleton(storage, KEY_CONSTANTS)
+}
+
+pub fn constants_read<S: ReadonlyStorage>(storage: &S) -> ReadonlySingleton<S, Constants> {
+    singleton_read(storage, KEY_CONSTANTS)
+}
+
+pub fn total_supply<S: Storage>(storage: &mut S) -> Singleton<S, Amount> {
+    singleton(storage, KEY_TOTAL_SUPPLY)
+}
+
+pub fn total_supply_read<S: ReadonlyStorage>(storage: &S) -> ReadonlySingleton<S, Amount> {
+    singleton_read(storage, KEY_TOTAL_SUPPLY)
 }
 
 #[cfg(test)]

--- a/erc20/src/tests.rs
+++ b/erc20/src/tests.rs
@@ -5,9 +5,10 @@ use cosmwasm::traits::{Api, ReadonlyStorage, Storage};
 use cosmwasm::types::{HumanAddr, Params};
 use cw_storage::ReadonlyPrefixedStorage;
 
-use crate::contract::{
-    bytes_to_u128, handle, init, query, read_u128, Constants, HandleMsg, InitMsg, InitialBalance,
-    QueryMsg, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES, PREFIX_CONFIG,
+use crate::contract::{bytes_to_u128, handle, init, query, read_u128};
+use crate::msg::{HandleMsg, InitMsg, InitialBalance, QueryMsg};
+use crate::state::{
+    Constants, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES, PREFIX_CONFIG,
 };
 
 static CANONICAL_LENGTH: usize = 20;

--- a/erc20/src/tests.rs
+++ b/erc20/src/tests.rs
@@ -1,15 +1,13 @@
 use cosmwasm::errors::Error;
 use cosmwasm::mock::{dependencies, mock_params};
-use cosmwasm::serde::from_slice;
 use cosmwasm::traits::{Api, ReadonlyStorage, Storage};
 use cosmwasm::types::{HumanAddr, Params};
 use cw_storage::ReadonlyPrefixedStorage;
 
-use crate::contract::{bytes_to_u128, handle, init, query, read_u128};
+use crate::contract::{handle, init, query, read_u128};
 use crate::msg::{HandleMsg, InitMsg, InitialBalance, QueryMsg};
 use crate::state::{
-    Amount, Constants, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES,
-    PREFIX_CONFIG,
+    constants_read, total_supply_read, Amount, Constants, PREFIX_ALLOWANCES, PREFIX_BALANCES,
 };
 
 static CANONICAL_LENGTH: usize = 20;
@@ -22,19 +20,11 @@ fn mock_params_height<A: Api>(api: &A, signer: &HumanAddr, height: i64, time: i6
 }
 
 fn get_constants<S: Storage>(storage: &S) -> Constants {
-    let config_storage = ReadonlyPrefixedStorage::new(PREFIX_CONFIG, storage);
-    let data = config_storage
-        .get(KEY_CONSTANTS)
-        .expect("no config data stored");
-    from_slice(&data).expect("invalid data")
+    constants_read(storage).load().unwrap()
 }
 
 fn get_total_supply<S: Storage>(storage: &S) -> u128 {
-    let config_storage = ReadonlyPrefixedStorage::new(PREFIX_CONFIG, storage);
-    let data = config_storage
-        .get(KEY_TOTAL_SUPPLY)
-        .expect("no decimals data stored");
-    return bytes_to_u128(&data).unwrap();
+    total_supply_read(storage).load().unwrap().parse().unwrap()
 }
 
 fn get_balance<S: ReadonlyStorage, A: Api>(api: &A, storage: &S, address: &HumanAddr) -> u128 {

--- a/erc20/src/tests.rs
+++ b/erc20/src/tests.rs
@@ -8,7 +8,8 @@ use cw_storage::ReadonlyPrefixedStorage;
 use crate::contract::{bytes_to_u128, handle, init, query, read_u128};
 use crate::msg::{HandleMsg, InitMsg, InitialBalance, QueryMsg};
 use crate::state::{
-    Constants, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES, PREFIX_CONFIG,
+    Amount, Constants, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES,
+    PREFIX_CONFIG,
 };
 
 static CANONICAL_LENGTH: usize = 20;
@@ -62,86 +63,6 @@ fn get_allowance<S: ReadonlyStorage, A: Api>(
     return read_u128(&owner_storage, spender_raw_address.as_bytes()).unwrap();
 }
 
-mod helpers {
-    use crate::contract::parse_u128;
-    use cosmwasm::errors::Error;
-
-    #[test]
-    fn works_for_simple_inputs() {
-        assert_eq!(parse_u128("0").expect("could not be parsed"), 0);
-        assert_eq!(parse_u128("1").expect("could not be parsed"), 1);
-        assert_eq!(parse_u128("345").expect("could not be parsed"), 345);
-        assert_eq!(
-            parse_u128("340282366920938463463374607431768211455").expect("could not be parsed"),
-            340282366920938463463374607431768211455
-        );
-    }
-
-    #[test]
-    fn works_for_leading_zeros() {
-        assert_eq!(parse_u128("01").expect("could not be parsed"), 1);
-        assert_eq!(parse_u128("001").expect("could not be parsed"), 1);
-        assert_eq!(parse_u128("0001").expect("could not be parsed"), 1);
-    }
-
-    #[test]
-    fn errors_for_empty_input() {
-        match parse_u128("") {
-            Ok(_) => panic!("must not pass"),
-            Err(Error::ContractErr { msg, .. }) => {
-                assert_eq!(msg, "Error while parsing string to u128")
-            }
-            Err(e) => panic!("unexpected error: {:?}", e),
-        }
-    }
-
-    #[test]
-    fn errors_for_values_out_of_range() {
-        match parse_u128("-1") {
-            Ok(_) => panic!("must not pass"),
-            Err(Error::ContractErr { msg, .. }) => {
-                assert_eq!(msg, "Error while parsing string to u128")
-            }
-            Err(e) => panic!("unexpected error: {:?}", e),
-        }
-
-        match parse_u128("340282366920938463463374607431768211456") {
-            Ok(_) => panic!("must not pass"),
-            Err(Error::ContractErr { msg, .. }) => {
-                assert_eq!(msg, "Error while parsing string to u128")
-            }
-            Err(e) => panic!("unexpected error: {:?}", e),
-        }
-    }
-
-    #[test]
-    fn fails_for_non_decadic_strings() {
-        match parse_u128("0xAB") {
-            Ok(_) => panic!("must not pass"),
-            Err(Error::ContractErr { msg, .. }) => {
-                assert_eq!(msg, "Error while parsing string to u128")
-            }
-            Err(e) => panic!("unexpected error: {:?}", e),
-        }
-
-        match parse_u128("0xab") {
-            Ok(_) => panic!("must not pass"),
-            Err(Error::ContractErr { msg, .. }) => {
-                assert_eq!(msg, "Error while parsing string to u128")
-            }
-            Err(e) => panic!("unexpected error: {:?}", e),
-        }
-
-        match parse_u128("0b1100") {
-            Ok(_) => panic!("must not pass"),
-            Err(Error::ContractErr { msg, .. }) => {
-                assert_eq!(msg, "Error while parsing string to u128")
-            }
-            Err(e) => panic!("unexpected error: {:?}", e),
-        }
-    }
-}
-
 mod init {
     use super::*;
 
@@ -154,7 +75,7 @@ mod init {
             decimals: 9,
             initial_balances: [InitialBalance {
                 address: HumanAddr("addr0000".to_string()),
-                amount: "11223344".to_string(),
+                amount: Amount::from("11223344"),
             }]
             .to_vec(),
         };
@@ -203,15 +124,15 @@ mod init {
             initial_balances: [
                 InitialBalance {
                     address: HumanAddr("addr0000".to_string()),
-                    amount: "11".to_string(),
+                    amount: Amount::from("11"),
                 },
                 InitialBalance {
                     address: HumanAddr("addr1111".to_string()),
-                    amount: "22".to_string(),
+                    amount: Amount::from("22"),
                 },
                 InitialBalance {
                     address: HumanAddr("addrbbbb".to_string()),
-                    amount: "33".to_string(),
+                    amount: Amount::from("33"),
                 },
             ]
             .to_vec(),
@@ -249,7 +170,7 @@ mod init {
             decimals: 9,
             initial_balances: [InitialBalance {
                 address: HumanAddr("addr0000".to_string()),
-                amount: "9007199254740993".to_string(),
+                amount: Amount::from("9007199254740993"),
             }]
             .to_vec(),
         };
@@ -275,7 +196,7 @@ mod init {
             decimals: 9,
             initial_balances: [InitialBalance {
                 address: HumanAddr("addr0000".to_string()),
-                amount: "100000000000000000000000000".to_string(),
+                amount: Amount::from("100000000000000000000000000"),
             }]
             .to_vec(),
         };
@@ -300,7 +221,7 @@ mod init {
             initial_balances: [InitialBalance {
                 address: HumanAddr("addr0000".to_string()),
                 // 2**128 = 340282366920938463463374607431768211456
-                amount: "340282366920938463463374607431768211456".to_string(),
+                amount: Amount::from("340282366920938463463374607431768211456"),
             }]
             .to_vec(),
         };
@@ -445,15 +366,15 @@ mod transfer {
             initial_balances: vec![
                 InitialBalance {
                     address: HumanAddr("addr0000".to_string()),
-                    amount: "11".to_string(),
+                    amount: Amount::from("11"),
                 },
                 InitialBalance {
                     address: HumanAddr("addr1111".to_string()),
-                    amount: "22".to_string(),
+                    amount: Amount::from("22"),
                 },
                 InitialBalance {
                     address: HumanAddr("addrbbbb".to_string()),
-                    amount: "33".to_string(),
+                    amount: Amount::from("33"),
                 },
             ],
         }
@@ -485,7 +406,7 @@ mod transfer {
         // Transfer
         let transfer_msg = HandleMsg::Transfer {
             recipient: HumanAddr("addr1111".to_string()),
-            amount: "1".to_string(),
+            amount: Amount::from("1"),
         };
         let params2 = mock_params_height(&deps.api, &HumanAddr("addr0000".to_string()), 450, 550);
         let transfer_result = handle(&mut deps, params2, transfer_msg).unwrap();
@@ -534,7 +455,7 @@ mod transfer {
         // Transfer
         let transfer_msg = HandleMsg::Transfer {
             recipient: HumanAddr("addr2323".to_string()),
-            amount: "1".to_string(),
+            amount: Amount::from("1"),
         };
         let params2 = mock_params_height(&deps.api, &HumanAddr("addr0000".to_string()), 450, 550);
         let transfer_result = handle(&mut deps, params2, transfer_msg).unwrap();
@@ -587,7 +508,7 @@ mod transfer {
         // Transfer
         let transfer_msg = HandleMsg::Transfer {
             recipient: HumanAddr("addr1111".to_string()),
-            amount: "0".to_string(),
+            amount: Amount::from("0"),
         };
         let params2 = mock_params_height(&deps.api, &HumanAddr("addr0000".to_string()), 450, 550);
         let transfer_result = handle(&mut deps, params2, transfer_msg).unwrap();
@@ -626,7 +547,7 @@ mod transfer {
         // Transfer
         let transfer_msg = HandleMsg::Transfer {
             recipient: sender.clone(),
-            amount: "3".to_string(),
+            amount: Amount::from("3"),
         };
         let params2 = mock_params_height(&deps.api, &sender, 450, 550);
         let transfer_result = handle(&mut deps, params2, transfer_msg).unwrap();
@@ -663,7 +584,7 @@ mod transfer {
         // Transfer
         let transfer_msg = HandleMsg::Transfer {
             recipient: HumanAddr("addr1111".to_string()),
-            amount: "12".to_string(),
+            amount: Amount::from("12"),
         };
         let params2 = mock_params_height(&deps.api, &HumanAddr("addr0000".to_string()), 450, 550);
         let transfer_result = handle(&mut deps, params2, transfer_msg);
@@ -703,15 +624,15 @@ mod approve {
             initial_balances: vec![
                 InitialBalance {
                     address: HumanAddr("addr0000".to_string()),
-                    amount: "11".to_string(),
+                    amount: Amount::from("11"),
                 },
                 InitialBalance {
                     address: HumanAddr("addr1111".to_string()),
-                    amount: "22".to_string(),
+                    amount: Amount::from("22"),
                 },
                 InitialBalance {
                     address: HumanAddr("addrbbbb".to_string()),
-                    amount: "33".to_string(),
+                    amount: Amount::from("33"),
                 },
             ],
         }
@@ -774,7 +695,7 @@ mod approve {
         let owner = HumanAddr("addr7654".to_string());
         let approve_msg1 = HandleMsg::Approve {
             spender: make_spender(),
-            amount: "334422".to_string(),
+            amount: Amount::from("334422"),
         };
         let params2 = mock_params_height(&deps.api, &owner, 450, 550);
         let transfer_result = handle(&mut deps, params2, approve_msg1).unwrap();
@@ -789,7 +710,7 @@ mod approve {
         // Updated approval
         let approve_msg2 = HandleMsg::Approve {
             spender: make_spender(),
-            amount: "777888".to_string(),
+            amount: Amount::from("777888"),
         };
         let params3 = mock_params_height(&deps.api, &owner, 450, 550);
         let transfer_result = handle(&mut deps, params3, approve_msg2).unwrap();
@@ -814,15 +735,15 @@ mod transfer_from {
             initial_balances: vec![
                 InitialBalance {
                     address: HumanAddr("addr0000".to_string()),
-                    amount: "11".to_string(),
+                    amount: Amount::from("11"),
                 },
                 InitialBalance {
                     address: HumanAddr("addr1111".to_string()),
-                    amount: "22".to_string(),
+                    amount: Amount::from("22"),
                 },
                 InitialBalance {
                     address: HumanAddr("addrbbbb".to_string()),
-                    amount: "33".to_string(),
+                    amount: Amount::from("33"),
                 },
             ],
         }
@@ -847,7 +768,7 @@ mod transfer_from {
         // Set approval
         let approve_msg = HandleMsg::Approve {
             spender: make_spender(),
-            amount: "4".to_string(),
+            amount: Amount::from("4"),
         };
         let params2 = mock_params_height(&deps.api, &owner, 450, 550);
         let approve_result = handle(&mut deps, params2, approve_msg).unwrap();
@@ -861,7 +782,7 @@ mod transfer_from {
         let fransfer_from_msg = HandleMsg::TransferFrom {
             owner: owner.clone(),
             recipient: recipient.clone(),
-            amount: "3".to_string(),
+            amount: Amount::from("3"),
         };
         let params3 = mock_params_height(&deps.api, spender, 450, 550);
         let transfer_result = handle(&mut deps, params3, fransfer_from_msg).unwrap();
@@ -891,7 +812,7 @@ mod transfer_from {
         // Set approval
         let approve_msg = HandleMsg::Approve {
             spender: make_spender(),
-            amount: "2".to_string(),
+            amount: Amount::from("2"),
         };
         let params2 = mock_params_height(&deps.api, &owner, 450, 550);
         let approve_result = handle(&mut deps, params2, approve_msg).unwrap();
@@ -905,7 +826,7 @@ mod transfer_from {
         let fransfer_from_msg = HandleMsg::TransferFrom {
             owner: owner.clone(),
             recipient: recipient.clone(),
-            amount: "3".to_string(),
+            amount: Amount::from("3"),
         };
         let params3 = mock_params_height(&deps.api, spender, 450, 550);
         let transfer_result = handle(&mut deps, params3, fransfer_from_msg);
@@ -933,7 +854,7 @@ mod transfer_from {
         // Set approval
         let approve_msg = HandleMsg::Approve {
             spender: make_spender(),
-            amount: "20".to_string(),
+            amount: Amount::from("20"),
         };
         let params2 = mock_params_height(&deps.api, &owner, 450, 550);
         let approve_result = handle(&mut deps, params2, approve_msg).unwrap();
@@ -947,7 +868,7 @@ mod transfer_from {
         let fransfer_from_msg = HandleMsg::TransferFrom {
             owner: owner.clone(),
             recipient: recipient.clone(),
-            amount: "15".to_string(),
+            amount: Amount::from("15"),
         };
         let params3 = mock_params_height(&deps.api, spender, 450, 550);
         let transfer_result = handle(&mut deps, params3, fransfer_from_msg);
@@ -983,15 +904,15 @@ mod query {
             initial_balances: vec![
                 InitialBalance {
                     address: address(1),
-                    amount: "11".to_string(),
+                    amount: Amount::from("11"),
                 },
                 InitialBalance {
                     address: address(2),
-                    amount: "22".to_string(),
+                    amount: Amount::from("22"),
                 },
                 InitialBalance {
                     address: address(3),
-                    amount: "33".to_string(),
+                    amount: Amount::from("33"),
                 },
             ],
         }
@@ -1040,7 +961,7 @@ mod query {
 
         let approve_msg = HandleMsg::Approve {
             spender: spender.clone(),
-            amount: "42".to_string(),
+            amount: Amount::from("42"),
         };
         let params2 = mock_params_height(&deps.api, &owner, 450, 550);
         let transfer_result = handle(&mut deps, params2, approve_msg).unwrap();
@@ -1069,7 +990,7 @@ mod query {
 
         let approve_msg = HandleMsg::Approve {
             spender: spender.clone(),
-            amount: "42".to_string(),
+            amount: Amount::from("42"),
         };
         let params2 = mock_params_height(&deps.api, &owner, 450, 550);
         let transfer_result = handle(&mut deps, params2, approve_msg).unwrap();

--- a/erc20/tests/integration.rs
+++ b/erc20/tests/integration.rs
@@ -5,9 +5,10 @@ use cosmwasm::types::{HumanAddr, Params};
 use cosmwasm_vm::testing::{handle, init, mock_instance, query};
 use cw_storage::ReadonlyPrefixedStorage;
 
-use cw_erc20::contract::{
-    bytes_to_u128, read_u128, Constants, HandleMsg, InitMsg, InitialBalance, QueryMsg,
-    KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES, PREFIX_CONFIG,
+use cw_erc20::contract::{bytes_to_u128, read_u128};
+use cw_erc20::msg::{HandleMsg, InitMsg, InitialBalance, QueryMsg};
+use cw_erc20::state::{
+    Constants, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES, PREFIX_CONFIG,
 };
 
 static WASM: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/cw_erc20.wasm");

--- a/erc20/tests/integration.rs
+++ b/erc20/tests/integration.rs
@@ -1,15 +1,13 @@
 use cosmwasm::mock::mock_params;
-use cosmwasm::serde::from_slice;
 use cosmwasm::traits::{Api, ReadonlyStorage, Storage};
 use cosmwasm::types::{HumanAddr, Params};
 use cosmwasm_vm::testing::{handle, init, mock_instance, query};
 use cw_storage::ReadonlyPrefixedStorage;
 
-use cw_erc20::contract::{bytes_to_u128, read_u128};
+use cw_erc20::contract::read_u128;
 use cw_erc20::msg::{HandleMsg, InitMsg, InitialBalance, QueryMsg};
 use cw_erc20::state::{
-    Amount, Constants, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES,
-    PREFIX_CONFIG,
+    constants_read, total_supply_read, Amount, Constants, PREFIX_ALLOWANCES, PREFIX_BALANCES,
 };
 
 static WASM: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/cw_erc20.wasm");
@@ -22,19 +20,11 @@ fn mock_params_height<A: Api>(api: &A, signer: &HumanAddr, height: i64, time: i6
 }
 
 fn get_constants<S: Storage>(storage: &S) -> Constants {
-    let config_storage = ReadonlyPrefixedStorage::new(PREFIX_CONFIG, storage);
-    let data = config_storage
-        .get(KEY_CONSTANTS)
-        .expect("no config data stored");
-    from_slice(&data).expect("invalid data")
+    constants_read(storage).load().unwrap()
 }
 
 fn get_total_supply<S: Storage>(storage: &S) -> u128 {
-    let config_storage = ReadonlyPrefixedStorage::new(PREFIX_CONFIG, storage);
-    let data = config_storage
-        .get(KEY_TOTAL_SUPPLY)
-        .expect("no decimals data stored");
-    return bytes_to_u128(&data).unwrap();
+    total_supply_read(storage).load().unwrap().parse().unwrap()
 }
 
 fn get_balance<S: ReadonlyStorage, A: Api>(api: &A, storage: &S, address: &HumanAddr) -> u128 {

--- a/erc20/tests/integration.rs
+++ b/erc20/tests/integration.rs
@@ -8,7 +8,8 @@ use cw_storage::ReadonlyPrefixedStorage;
 use cw_erc20::contract::{bytes_to_u128, read_u128};
 use cw_erc20::msg::{HandleMsg, InitMsg, InitialBalance, QueryMsg};
 use cw_erc20::state::{
-    Constants, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES, PREFIX_CONFIG,
+    Amount, Constants, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES,
+    PREFIX_CONFIG,
 };
 
 static WASM: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/cw_erc20.wasm");
@@ -80,15 +81,15 @@ fn init_msg() -> InitMsg {
         initial_balances: [
             InitialBalance {
                 address: address(1),
-                amount: "11".to_string(),
+                amount: Amount::from("11"),
             },
             InitialBalance {
                 address: address(2),
-                amount: "22".to_string(),
+                amount: Amount::from("22"),
             },
             InitialBalance {
                 address: address(3),
-                amount: "33".to_string(),
+                amount: Amount::from("33"),
             },
         ]
         .to_vec(),
@@ -140,7 +141,7 @@ fn transfer_works() {
     // Transfer
     let transfer_msg = HandleMsg::Transfer {
         recipient: recipient.clone(),
-        amount: "1".to_string(),
+        amount: Amount::from("1"),
     };
     let params2 = mock_params_height(&deps.api, &sender, 877, 0);
     let transfer_result = handle(&mut deps, params2, transfer_msg).unwrap();
@@ -173,7 +174,7 @@ fn approve_works() {
     // Approve
     let approve_msg = HandleMsg::Approve {
         spender: spender.clone(),
-        amount: "42".to_string(),
+        amount: Amount::from("42"),
     };
     let params2 = mock_params_height(&deps.api, &owner, 877, 0);
     let approve_result = handle(&mut deps, params2, approve_msg).unwrap();
@@ -208,7 +209,7 @@ fn transfer_from_works() {
     // Approve
     let approve_msg = HandleMsg::Approve {
         spender: spender.clone(),
-        amount: "42".to_string(),
+        amount: Amount::from("42"),
     };
     let params2 = mock_params_height(&deps.api, &owner, 877, 0);
     let approve_result = handle(&mut deps, params2, approve_msg).unwrap();
@@ -219,7 +220,7 @@ fn transfer_from_works() {
     let transfer_from_msg = HandleMsg::TransferFrom {
         owner: owner.clone(),
         recipient: recipient.clone(),
-        amount: "2".to_string(),
+        amount: Amount::from("2"),
     };
     let params3 = mock_params_height(&deps.api, &spender, 878, 0);
     let transfer_from_result = handle(&mut deps, params3, transfer_from_msg).unwrap();


### PR DESCRIPTION
No longer do manual byte encoding of u128 to store on disk, but use std serde-json compatible types (Amount), so we can use `cw_storage` helpers for all read/write boilerplate