### PR TITLE
Update escrow expiry types

### DIFF
--- a/escrow/schema/init_msg.json
+++ b/escrow/schema/init_msg.json
@@ -13,11 +13,17 @@
       "$ref": "#/definitions/HumanAddr"
     },
     "end_height": {
-      "type": "integer",
+      "type": [
+        "integer",
+        "null"
+      ],
       "format": "int64"
     },
     "end_time": {
-      "type": "integer",
+      "type": [
+        "integer",
+        "null"
+      ],
       "format": "int64"
     },
     "recipient": {

--- a/escrow/schema/state.json
+++ b/escrow/schema/state.json
@@ -14,11 +14,17 @@
       "$ref": "#/definitions/CanonicalAddr"
     },
     "end_height": {
-      "type": "integer",
+      "type": [
+        "integer",
+        "null"
+      ],
       "format": "int64"
     },
     "end_time": {
-      "type": "integer",
+      "type": [
+        "integer",
+        "null"
+      ],
       "format": "int64"
     },
     "recipient": {

--- a/escrow/src/contract.rs
+++ b/escrow/src/contract.rs
@@ -12,14 +12,25 @@ pub struct State {
     pub arbiter: CanonicalAddr,
     pub recipient: CanonicalAddr,
     pub source: CanonicalAddr,
-    pub end_height: i64,
-    pub end_time: i64,
+    pub end_height: Option<i64>,
+    pub end_time: Option<i64>,
 }
 
 impl State {
     fn is_expired(&self, env: &Env) -> bool {
-        (self.end_height != 0 && env.block.height >= self.end_height)
-            || (self.end_time != 0 && env.block.time >= self.end_time)
+        if let Some(end_height) = self.end_height {
+            if env.block.height >= end_height {
+                return true;
+            }
+        }
+
+        if let Some(end_time) = self.end_time {
+            if env.block.time >= end_time {
+                return true;
+            }
+        }
+
+        return false;
     }
 }
 
@@ -134,12 +145,12 @@ mod tests {
     use cosmwasm::traits::Api;
     use cosmwasm::types::{coin, HumanAddr};
 
-    fn init_msg(height: i64, time: i64) -> InitMsg {
+    fn init_msg_expire_by_height(height: i64) -> InitMsg {
         InitMsg {
             arbiter: HumanAddr::from("verifies"),
             recipient: HumanAddr::from("benefits"),
-            end_height: height,
-            end_time: time,
+            end_height: Some(height),
+            end_time: None,
         }
     }
 
@@ -161,7 +172,7 @@ mod tests {
     fn proper_initialization() {
         let mut deps = dependencies(20);
 
-        let msg = init_msg(1000, 0);
+        let msg = init_msg_expire_by_height(1000);
         let env = mock_env_height(&deps.api, "creator", &coin("1000", "earth"), &[], 876, 0);
         let res = init(&mut deps, env, msg).unwrap();
         assert_eq!(0, res.messages.len());
@@ -183,8 +194,8 @@ mod tests {
                     .api
                     .canonical_address(&HumanAddr::from("creator"))
                     .unwrap(),
-                end_height: 1000,
-                end_time: 0,
+                end_height: Some(1000),
+                end_time: None,
             }
         );
     }
@@ -193,7 +204,7 @@ mod tests {
     fn cannot_initialize_expired() {
         let mut deps = dependencies(20);
 
-        let msg = init_msg(1000, 0);
+        let msg = init_msg_expire_by_height(1000);
         let env = mock_env_height(&deps.api, "creator", &coin("1000", "earth"), &[], 1001, 0);
         let res = init(&mut deps, env, msg);
         assert!(res.is_err());
@@ -209,7 +220,7 @@ mod tests {
         let mut deps = dependencies(20);
 
         // initialize the store
-        let msg = init_msg(1000, 0);
+        let msg = init_msg_expire_by_height(1000);
         let env = mock_env_height(&deps.api, "creator", &coin("1000", "earth"), &[], 876, 0);
         let init_res = init(&mut deps, env, msg).unwrap();
         assert_eq!(0, init_res.messages.len());
@@ -298,7 +309,7 @@ mod tests {
         let mut deps = dependencies(20);
 
         // initialize the store
-        let msg = init_msg(1000, 0);
+        let msg = init_msg_expire_by_height(1000);
         let env = mock_env_height(&deps.api, "creator", &coin("1000", "earth"), &[], 876, 0);
         let init_res = init(&mut deps, env, msg).unwrap();
         assert_eq!(0, init_res.messages.len());

--- a/escrow/src/msg.rs
+++ b/escrow/src/msg.rs
@@ -7,11 +7,13 @@ use cosmwasm::types::{Coin, HumanAddr};
 pub struct InitMsg {
     pub arbiter: HumanAddr,
     pub recipient: HumanAddr,
-    // you can set a last time or block height the contract is valid at
-    // if *either* is non-zero and below current state, the contract is considered expired
-    // and will be returned to the original funder
-    pub end_height: i64,
-    pub end_time: i64,
+    /// When set, this is the last height at which the escrow is valid. After that height,
+    /// the escrow is expired and can be returned to the original funder (via "refund").
+    pub end_height: Option<i64>,
+    /// When set, this is the last time (in seconds since epoch 00:00:00 UTC on 1 January 1970)
+    /// at which the escrow is valid. After that time, the escrow is expired and can be
+    /// returned to the original funder (via "refund").
+    pub end_time: Option<i64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/escrow/src/msg.rs
+++ b/escrow/src/msg.rs
@@ -7,12 +7,12 @@ use cosmwasm::types::{Coin, HumanAddr};
 pub struct InitMsg {
     pub arbiter: HumanAddr,
     pub recipient: HumanAddr,
-    /// When set, this is the last height at which the escrow is valid. After that height,
-    /// the escrow is expired and can be returned to the original funder (via "refund").
+    /// When end height set and block height exceeds this value, the escrow is expired.
+    /// Once an escrow is expired, it can be returned to the original funder (via "refund").
     pub end_height: Option<i64>,
-    /// When set, this is the last time (in seconds since epoch 00:00:00 UTC on 1 January 1970)
-    /// at which the escrow is valid. After that time, the escrow is expired and can be
-    /// returned to the original funder (via "refund").
+    /// When end time (in seconds since epoch 00:00:00 UTC on 1 January 1970) is set and
+    /// block time exceeds this value, the escrow is expired.
+    /// Once an escrow is expired, it can be returned to the original funder (via "refund").
     pub end_time: Option<i64>,
 }
 

--- a/escrow/tests/integration.rs
+++ b/escrow/tests/integration.rs
@@ -41,12 +41,12 @@ static WASM: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/cw
 // You can uncomment this line instead to test productionified build from cosmwasm-opt
 // static WASM: &[u8] = include_bytes!("../contract.wasm");
 
-fn init_msg(height: i64, time: i64) -> InitMsg {
+fn init_msg_expire_by_height(height: i64) -> InitMsg {
     InitMsg {
         arbiter: HumanAddr::from("verifies"),
         recipient: HumanAddr::from("benefits"),
-        end_height: height,
-        end_time: time,
+        end_height: Some(height),
+        end_time: None,
     }
 }
 
@@ -68,7 +68,7 @@ fn mock_env_height<A: Api>(
 fn proper_initialization() {
     let mut deps = mock_instance(WASM);
 
-    let msg = init_msg(1000, 0);
+    let msg = init_msg_expire_by_height(1000);
     let env = mock_env_height(&deps.api, "creator", &coin("1000", "earth"), &[], 876, 0);
     let res = init(&mut deps, env, msg).unwrap();
     assert_eq!(0, res.messages.len());
@@ -91,8 +91,8 @@ fn proper_initialization() {
                     .api
                     .canonical_address(&HumanAddr::from("creator"))
                     .unwrap(),
-                end_height: 1000,
-                end_time: 0,
+                end_height: Some(1000),
+                end_time: None,
             }
         );
     });
@@ -102,7 +102,7 @@ fn proper_initialization() {
 fn cannot_initialize_expired() {
     let mut deps = mock_instance(WASM);
 
-    let msg = init_msg(1000, 0);
+    let msg = init_msg_expire_by_height(1000);
     let env = mock_env_height(&deps.api, "creator", &coin("1000", "earth"), &[], 1001, 0);
     let res = init(&mut deps, env, msg);
     if let ContractResult::Err(msg) = res {
@@ -117,7 +117,7 @@ fn handle_approve() {
     let mut deps = mock_instance(WASM);
 
     // initialize the store
-    let msg = init_msg(1000, 0);
+    let msg = init_msg_expire_by_height(1000);
     let env = mock_env_height(&deps.api, "creator", &coin("1000", "earth"), &[], 876, 0);
     let init_res = init(&mut deps, env, msg).unwrap();
     assert_eq!(0, init_res.messages.len());
@@ -204,7 +204,7 @@ fn handle_refund() {
     let mut deps = mock_instance(WASM);
 
     // initialize the store
-    let msg = init_msg(1000, 0);
+    let msg = init_msg_expire_by_height(1000);
     let env = mock_env_height(&deps.api, "creator", &coin("1000", "earth"), &[], 876, 0);
     let init_res = init(&mut deps, env, msg).unwrap();
     assert_eq!(0, init_res.messages.len());


### PR DESCRIPTION
This

1. Encodes setting `end_height`/`end_type` as Option instead of zero value
2. Improves documentation of the fields, clarifying that each of them can independently trigger an expiery
3. Fix `>=` to `>` in `is_expired` to match the documented behaviour

I'd also love to allow the creation of expired escrows, but I'm afraid this starts a long debate about minimalism and correctness vs. preventing users to shoot themselves into the foot.